### PR TITLE
fix: missing preconf fee validation

### DIFF
--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -102,6 +102,13 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
 		return core.ErrTipAboveFeeCap
 	}
+	// CHANGE(limechain):
+	if tx.Type() == types.InclusionPreconfirmationTxType {
+		_, err := tx.EffectiveGasTip(head.BaseFee)
+		if err != nil {
+			return err
+		}
+	}
 	// CHANGE(taiko): check gasFeeCap.
 	if os.Getenv("TAIKO_TEST") == "" && tx.GasFeeCap().Cmp(common.Big0) == 0 {
 		return errors.New("max fee per gas is 0")


### PR DESCRIPTION
There is a case where sending too small `GasFeeCap` amount (with an increased base fee for pre-confirmation txs) leads to a negative value for the `EffectiveGasTip`, which can cause Geth to crash.