### PR TITLE
fix: disallow sending preconf txs with future nonces

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1828,11 +1828,27 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		return common.Hash{}, err
 	}
 
+	head := b.CurrentBlock()
+	signer := types.MakeSigner(b.ChainConfig(), head.Number, head.Time)
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
 	// CHANGE(limechain): check whether inclusion constraints are met.
 	if tx.Type() == types.InclusionPreconfirmationTxType {
 		err := validateInclusionConstraints(b, tx)
 		if err != nil {
 			return common.Hash{}, err
+		}
+
+		// Do not allow nonce gaps for inclusion txs.
+		nonce, err := b.GetPoolNonce(ctx, from)
+		if err != nil {
+			return common.Hash{}, err
+		}
+		if tx.Nonce() > nonce {
+			return common.Hash{}, fmt.Errorf("inclusion tx nonce gap is not allowed, tx nonce: [%d], pool nonce: [%d]", nonce, tx.Nonce())
 		}
 	}
 
@@ -1844,12 +1860,6 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 		return common.Hash{}, err
 	}
 	// Print a log with full tx details for manual investigations and interventions
-	head := b.CurrentBlock()
-	signer := types.MakeSigner(b.ChainConfig(), head.Number, head.Time)
-	from, err := types.Sender(signer, tx)
-	if err != nil {
-		return common.Hash{}, err
-	}
 
 	if tx.To() == nil {
 		addr := crypto.CreateAddress(from, tx.Nonce())


### PR DESCRIPTION
Disallow pre-confirmation txs with future nonces, since there is no guarantee that they will be valid and included in a block